### PR TITLE
Add search functionality

### DIFF
--- a/update.go
+++ b/update.go
@@ -34,6 +34,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Create our ticker command which will be our "default return" in the absence of any other commands.
 	tick := makeTick(5 * m.tickInterval)
 
+	if m.searchString == "" {
+		m.refreshFilteredExitNodes()
+	}
+
 	switch msg := msg.(type) {
 	// On tick, fetch a new state.
 	case tickMsg:
@@ -42,61 +46,175 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// When the state updater returns, update our model.
 	case stateMsg:
 		m.state = libts.State(msg)
+		m.refreshFilteredExitNodes()
 
 	case tea.WindowSizeMsg:
 		m.terminalWidth = msg.Width
 		m.terminalHeight = msg.Height
 
 	case tea.KeyMsg:
-		switch msg.String() {
-
-		case "ctrl+c", "q":
-			return m, tea.Quit
-
-		case "up":
-			if m.exitNodeCursor > -1 {
-				m.exitNodeCursor--
-			}
-
-		case "down":
-			if m.exitNodeCursor < len(m.state.SortedExitNodes)-1 {
-				m.exitNodeCursor++
-			}
-
-		// Select exit node on enter or space.
-		case "enter", " ":
-			var exitNode *ipnstate.PeerStatus
-
-			// If they have an exit node selected and not "None", use it.
-			if m.exitNodeCursor > -1 {
-				exitNode = m.state.SortedExitNodes[m.exitNodeCursor]
-
-				// If this exit node is already selected, don't do anything.
-				if m.state.CurrentExitNode != nil && *m.state.CurrentExitNode == exitNode.ID {
-					return m, tick
-				}
-			}
-
-			// Eagerly update the model, and therefore the UI.
-			if exitNode == nil {
-				m.state.CurrentExitNode = nil
-			} else {
-				m.state.CurrentExitNode = &exitNode.ID
-			}
-
-			// Asynchronously use the Tailscale API to update the exit node.
-			cmd := func() tea.Msg {
-				libts.SetExitNode(ctx, exitNode)
-				return nil
-			}
-			return m, cmd
+		switch m.keyMode {
+		case normalKeyMode:
+			return m.handleNormalModeKeys(msg, tick)
+		case searchKeyMode:
+			return m.handleSearchModeKeys(msg, tick)
 		}
 	}
 
-	// Make sure the exit node cursor doesn't end up out of bounds if we lose exit nodes.
-	if m.exitNodeCursor > len(m.state.SortedExitNodes)-1 {
-		m.exitNodeCursor = -1
+	m.validateSelectedExitNode()
+	return m, tick
+}
+
+func (m *model) findSelectedExitNode() (int, *ipnstate.PeerStatus) {
+	if m.selectedExitNode == "" {
+		return -1, nil
+	}
+	for i, node := range m.filteredExitNodes {
+		if node.ID == m.selectedExitNode {
+			return i, node
+		}
+	}
+	return -1, nil
+}
+
+func (m *model) validateSelectedExitNode() {
+	// Make sure the exit node cursor doesn't point to a non-existing node.
+	if m.selectedExitNode != "" {
+		i, _ := m.findSelectedExitNode()
+		if i == -1 {
+			m.selectedExitNode = ""
+		}
+	}
+}
+
+func (m *model) selectPreviousExitNode() {
+	i, _ := m.findSelectedExitNode()
+	if i > 0 {
+		m.selectedExitNode = m.filteredExitNodes[i-1].ID
+	} else {
+		m.selectedExitNode = ""
+	}
+}
+
+func (m *model) selectNextExitNode() {
+	i, _ := m.findSelectedExitNode()
+	if i+1 < len(m.filteredExitNodes) {
+		m.selectedExitNode = m.filteredExitNodes[i+1].ID
+	}
+}
+
+func (m *model) handleNormalModeKeys(msg tea.KeyMsg, tick tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "/":
+		m.keyMode = searchKeyMode
+		return m, tick
+
+	case "ctrl+c", "q":
+		return m, tea.Quit
+
+	case "up":
+		m.selectPreviousExitNode()
+
+	case "down":
+		m.selectNextExitNode()
+
+	case "r":
+		m.refreshFilteredExitNodes()
+
+	// Select exit node on enter or space.
+	case "enter", " ":
+		// If they have an exit node selected and not "None", use it.
+		_, exitNode := m.findSelectedExitNode()
+		return m.selectExitNode(exitNode, tick)
+	}
+	return m, tick
+}
+
+func (m *model) selectExitNode(exitNode *ipnstate.PeerStatus, tick tea.Cmd) (tea.Model, tea.Cmd) {
+	// If this exit node is already selected, don't do anything.
+	if exitNode != nil && m.state.CurrentExitNode != nil && *m.state.CurrentExitNode == exitNode.ID {
+		return m, tick
 	}
 
+	// Eagerly update the model, and therefore the UI.
+	if exitNode == nil {
+		m.state.CurrentExitNode = nil
+	} else {
+		m.state.CurrentExitNode = &exitNode.ID
+	}
+
+	// Asynchronously use the Tailscale API to update the exit node.
+	cmd := func() tea.Msg {
+		libts.SetExitNode(ctx, exitNode)
+		return nil
+	}
+	return m, cmd
+}
+
+func isHostnameCharacter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '-'
+}
+
+func (m *model) handleSearchModeKeys(msg tea.KeyMsg, tick tea.Cmd) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	switch {
+	case key == "esc":
+		m.keyMode = normalKeyMode
+		m.searchString = ""
+		m.refreshFilteredExitNodes()
+
+	case len(key) == 1 && isHostnameCharacter(key[0]):
+		m.searchString += key
+		m.refreshFilteredExitNodes()
+
+	case key == tea.KeyBackspace.String() && len(m.searchString) > 0:
+		m.searchString = m.searchString[:len(m.searchString)-1]
+		m.refreshFilteredExitNodes()
+
+	case key == "up":
+		m.selectPreviousExitNode()
+
+	case key == "down":
+		m.selectNextExitNode()
+
+	case key == "enter":
+		// If they have an exit node selected and not "None", use it.
+		_, exitNode := m.findSelectedExitNode()
+		return m.selectExitNode(exitNode, tick)
+	}
 	return m, tick
+}
+
+func matchesSearchString(haystack string, needle string) bool {
+	haystackPos := 0
+	for _, b := range []byte(needle) {
+		if haystackPos >= len(haystack) {
+			return false
+		}
+		found := false
+		for ; haystackPos < len(haystack) && !found; haystackPos++ {
+			if haystack[haystackPos] == b {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *model) refreshFilteredExitNodes() {
+	if m.searchString == "" {
+		m.filteredExitNodes = m.state.SortedExitNodes
+	}
+	m.filteredExitNodes = nil
+	for _, choice := range m.state.SortedExitNodes {
+		isActive := m.state.CurrentExitNode != nil && choice.ID == *m.state.CurrentExitNode
+		name := libts.PeerName(choice)
+		isSelected := m.selectedExitNode == choice.ID
+		if isActive || isSelected || matchesSearchString(name, m.searchString) {
+			m.filteredExitNodes = append(m.filteredExitNodes, choice)
+		}
+	}
 }

--- a/view.go
+++ b/view.go
@@ -158,23 +158,38 @@ func (m model) View() string {
 				Render("Exit Nodes") + ">")
 
 		// Exit node submenu. (Currently hardcoded, in the future there will be multiple.)
-		subMenu := ""
-		{
-			subMenu = listItem("None", m.exitNodeCursor == -1, m.state.CurrentExitNode == nil, false)
-
-			subMenu += lipgloss.NewStyle().
-				Faint(true).
-				Render("  --") + "\n"
-
-			for i, choice := range m.state.SortedExitNodes {
-				isActive := m.state.CurrentExitNode != nil && choice.ID == *m.state.CurrentExitNode
-				subMenu += listItem(libts.PeerName(choice), m.exitNodeCursor == i, isActive, !choice.Online)
-			}
-		}
+		subMenu := m.exitNodeSubmenu()
 
 		section := lipgloss.JoinHorizontal(lipgloss.Top, mainMenu, subMenu)
 		s.WriteString(section)
 	}
 
 	return s.String()
+}
+
+func (m *model) exitNodeSubmenu() string {
+	subMenu := ""
+	if m.keyMode == searchKeyMode {
+		subMenu += "Search: "
+		subMenu += lipgloss.NewStyle().
+			Underline(true).
+			Foreground(white).
+			Render(m.searchString)
+		subMenu += "\n"
+	}
+
+	subMenu += listItem("None", m.selectedExitNode == "", m.state.CurrentExitNode == nil, false)
+
+	subMenu += lipgloss.NewStyle().
+		Faint(true).
+		Render("  --") + "\n"
+
+	nodes := m.filteredExitNodes
+	for _, choice := range nodes {
+		isActive := m.state.CurrentExitNode != nil && choice.ID == *m.state.CurrentExitNode
+		isSelected := m.selectedExitNode == choice.ID
+		name := libts.PeerName(choice)
+		subMenu += listItem(name, isSelected, isActive, !choice.Online)
+	}
+	return subMenu
 }


### PR DESCRIPTION
Pressing `/` switches into filtering mode and lets the user type a search string. The filtering is done by looking for the characters of the search string in the node name, maintaining the order, but not requiring the characters to be consequtive.

For example, `ob` will match `foo-bar`.

The filtered list also includes the currently active exit node, and the node that has a cursor on it, regardless of the name.