### PR TITLE
fix: run with 'nix run'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,12 +31,6 @@
         let
           pkgs = nixpkgsFor.${system};
           pname = "tsui";
-
-          linuxInterpreters = {
-            x86_64 = "/lib64/ld-linux-x86-64.so.2"; 
-            aarch64 = "/lib/ld-linux-aarch64.so.1";
-          };
-          linuxInterpreter = linuxInterpreters.${pkgs.stdenv.hostPlatform.parsed.cpu.name};
         in
         {
           tsui = pkgs.buildGoModule {
@@ -65,11 +59,6 @@
             vendorHash = "sha256-FIbkPE5KQ4w7Tc7kISQ7ZYFZAoMNGiVlFWzt8BPCf+A=";
 
             buildInputs = dependenciesFor pkgs;
-
-            # Un-Nix the build so it can dlopen() X11 outside of Nix environments.
-            preFixup = if pkgs.stdenv.isLinux then ''
-              patchelf --remove-rpath --set-interpreter ${linuxInterpreter} $out/bin/${pname}
-            '' else null;
           };
         });
 


### PR DESCRIPTION
The standard nix builds creates a binary which is reproducible with pinned shared libraries in `/nix/store` as well as a pinned library loader (also located in `/nix/store`).

However the `preFixup` phase is replacing the reproducible and pinned library loader by one which is hopefully located in `/lib64/ld-linux-x86-64.so.2` (e.g. for `x86-64` systems). I don't understand this fix because:

- It breaks reproducibility and pinning because there is no guarantee that the file in `/lib64/ld-linux-x86-64.so.2` exists (e.g. on nixos systems) or that it is compatible (e.g. on system with a more recent libc).
- It does not bring any other benefit of making the binary self contained because it still depends on a few shared libraries:

```
	linux-vdso.so.1 (0x00007f95bad0d000)
	libX11.so.6 => /nix/store/44q9wnzpgv77rl0yjszs0bac5apk2c83-libX11-1.8.9/lib/libX11.so.6 (0x00007f95babc2000)
	libpthread.so.0 => /nix/store/dbcw19dshdwnxdv5q2g6wldj6syyvq7l-glibc-2.39-52/lib/libpthread.so.0 (0x00007f95babbd000)
	libresolv.so.2 => /nix/store/dbcw19dshdwnxdv5q2g6wldj6syyvq7l-glibc-2.39-52/lib/libresolv.so.2 (0x00007f95babac000)
	libc.so.6 => /nix/store/dbcw19dshdwnxdv5q2g6wldj6syyvq7l-glibc-2.39-52/lib/libc.so.6 (0x00007f95ba9bf000)
	libxcb.so.1 => /nix/store/inw0qwiz9mq2748g0whfa43q2qs2ic60-libxcb-1.17.0/lib/libxcb.so.1 (0x00007f95ba992000)
	/nix/store/dbcw19dshdwnxdv5q2g6wldj6syyvq7l-glibc-2.39-52/lib/ld-linux-x86-64.so.2 => /nix/store/wlffq5p6mxxgfap10sav3ij936jzqm59-glibc-2.39-52/lib64/ld-linux-x86-64.so.2 (0x00007f95bad0f000)
	libXau.so.6 => /nix/store/wgzlxm5hzkpfzaa1qjc4pzzc9fhkwf2c-libXau-1.0.11/lib/libXau.so.6 (0x00007f95ba98d000)
	libXdmcp.so.6 => /nix/store/sg6xmva8xipj3mw1ip22n4f6vqmzb47r-libXdmcp-1.1.5/lib/libXdmcp.so.6 (0x00007f95ba985000)
```

Note that I don't really understand the comment:

> Un-Nix the build so it can dlopen() X11 outside of Nix environments.

Alternates solutions:

- Either build the binary in fully static mode, so there is no shared libraries and library loader.
- Provide two builds artifacts, one (the default) which does not do the patch and can hence be run directly using `nix run` and one other which does this patching.

Note that with this commit, users can directly run `tsui` using `nix run 'github:neuralinkcorp/tsui'` (once merged).