### PR TITLE
Support Wayland clipboard with wl-copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ nix build
 
 ### With Go
 
-If you want to use Nix, you can still build with the Go toolchain. You will need Go installed and, on Linux, `libx11-dev`. On macOS, you may also need the XCode command line tools.
+If you want to use Nix, you can still build with the Go toolchain. You will need Go installed and, on Linux, `libx11-dev`. On Wayland Linux sessions, install `wl-clipboard` if you want native Wayland clipboard support; tsui falls back to X11 when `wl-copy` is unavailable. On macOS, you may also need the XCode command line tools.
 
 Develop:
 

--- a/clipboard/clipboard_linux.go
+++ b/clipboard/clipboard_linux.go
@@ -15,9 +15,14 @@ int writeString(
 import "C"
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
 	"runtime"
 	"runtime/cgo"
 	"sync"
+	"time"
 	"unsafe"
 )
 
@@ -27,6 +32,41 @@ func WriteString(str string) error {
 	lock.Lock()
 	defer lock.Unlock()
 
+	return writeLinuxString(str, os.Getenv("WAYLAND_DISPLAY"), exec.LookPath, writeWaylandString, writeX11String)
+}
+
+func writeLinuxString(
+	str string,
+	waylandDisplay string,
+	lookPath func(string) (string, error),
+	writeWayland func(string) error,
+	writeX11 func(string) error,
+) error {
+	if waylandDisplay != "" {
+		if _, err := lookPath("wl-copy"); err == nil {
+			if err := writeWayland(str); err == nil {
+				return nil
+			}
+		}
+	}
+
+	return writeX11(str)
+}
+
+func writeWaylandString(str string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "wl-copy")
+	cmd.Stdin = bytes.NewBufferString(str)
+	if err := cmd.Run(); err != nil {
+		return errUnavailable
+	}
+
+	return nil
+}
+
+func writeX11String(str string) error {
 	buf := []byte(str)
 
 	status := make(chan int)

--- a/clipboard/clipboard_linux_test.go
+++ b/clipboard/clipboard_linux_test.go
@@ -1,0 +1,115 @@
+package clipboard
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWriteLinuxStringUsesX11WhenNotWayland(t *testing.T) {
+	calledX11 := false
+
+	err := writeLinuxString("hello", "", func(string) (string, error) {
+		t.Fatal("lookPath should not be called outside Wayland")
+		return "", nil
+	}, func(string) error {
+		t.Fatal("writeWayland should not be called outside Wayland")
+		return nil
+	}, func(str string) error {
+		calledX11 = true
+		if str != "hello" {
+			t.Fatalf("writeX11 got %q, want hello", str)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !calledX11 {
+		t.Fatal("writeX11 was not called")
+	}
+}
+
+func TestWriteLinuxStringUsesWaylandWhenAvailable(t *testing.T) {
+	calledWayland := false
+
+	err := writeLinuxString("hello", "wayland-1", func(name string) (string, error) {
+		if name != "wl-copy" {
+			t.Fatalf("lookPath got %q, want wl-copy", name)
+		}
+		return "/bin/wl-copy", nil
+	}, func(str string) error {
+		calledWayland = true
+		if str != "hello" {
+			t.Fatalf("writeWayland got %q, want hello", str)
+		}
+		return nil
+	}, func(string) error {
+		t.Fatal("writeX11 should not be called when Wayland succeeds")
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !calledWayland {
+		t.Fatal("writeWayland was not called")
+	}
+}
+
+func TestWriteLinuxStringFallsBackWhenWlCopyMissing(t *testing.T) {
+	calledX11 := false
+
+	err := writeLinuxString("hello", "wayland-1", func(string) (string, error) {
+		return "", errors.New("not found")
+	}, func(string) error {
+		t.Fatal("writeWayland should not be called when wl-copy is missing")
+		return nil
+	}, func(string) error {
+		calledX11 = true
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !calledX11 {
+		t.Fatal("writeX11 was not called")
+	}
+}
+
+func TestWriteLinuxStringFallsBackWhenWaylandFails(t *testing.T) {
+	calledX11 := false
+
+	err := writeLinuxString("hello", "wayland-1", func(string) (string, error) {
+		return "/bin/wl-copy", nil
+	}, func(string) error {
+		return errors.New("wayland failed")
+	}, func(string) error {
+		calledX11 = true
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !calledX11 {
+		t.Fatal("writeX11 was not called")
+	}
+}
+
+func TestWriteLinuxStringReturnsX11Error(t *testing.T) {
+	want := errors.New("x11 failed")
+
+	err := writeLinuxString("hello", "wayland-1", func(string) (string, error) {
+		return "/bin/wl-copy", nil
+	}, func(string) error {
+		return errors.New("wayland failed")
+	}, func(string) error {
+		return want
+	})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
       dependenciesFor = pkgs : with pkgs; []
         ++ (lib.optionals stdenv.isLinux [
-          # For Linux clipboard support.
+          # For X11 clipboard fallback.
           xorg.libX11.dev
         ])
         ++ (lib.optionals stdenv.isDarwin [
@@ -66,9 +66,16 @@
 
             buildInputs = dependenciesFor pkgs;
 
-            # Un-Nix the build so it can dlopen() X11 outside of Nix environments.
-            preFixup = if pkgs.stdenv.isLinux then ''
+            nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+              pkgs.makeWrapper
+            ];
+
+            postFixup = if pkgs.stdenv.isLinux then ''
+              # Un-Nix the build so it can dlopen() X11 outside of Nix environments.
               patchelf --remove-rpath --set-interpreter ${linuxInterpreter} $out/bin/${pname}
+
+              wrapProgram $out/bin/${pname} \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.wl-clipboard ]}
             '' else null;
           };
         });


### PR DESCRIPTION
## Summary
- use wl-copy for clipboard writes when running under Wayland
- fall back to the existing X11 clipboard implementation when wl-copy is unavailable or fails
- wrap the Nix Linux package with wl-clipboard on PATH so wl-copy is available at runtime
- add unit tests for the Linux clipboard selection and fallback logic

Fixes #11

## Tests
- go test ./...
- nix build with flakes enabled; verified result/bin/tsui wrapper includes wl-clipboard on PATH