### PR TITLE
Add peer machine details submenu

### DIFF
--- a/menus.go
+++ b/menus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -41,6 +42,7 @@ func buildNetworkDevicesSubmenuSection(title string, peers []*ipnstate.PeerStatu
 			items = append(items, &ui.LabeledSubmenuItem{
 				Label:           peerName,
 				AdditionalLabel: osName,
+				ChildSubmenu:    buildMachineDetailsSubmenu(peer),
 				OnActivate: func() tea.Msg {
 					err := clipboard.WriteString(peer.TailscaleIPs[0].String())
 					if err != nil {
@@ -56,6 +58,108 @@ func buildNetworkDevicesSubmenuSection(title string, peers []*ipnstate.PeerStatu
 	return items
 }
 
+func buildMachineDetailsSubmenu(peer *ipnstate.PeerStatus) *ui.Submenu {
+	peerName := libts.PeerName(peer)
+	items := []ui.SubmenuItem{
+		&ui.TitleSubmenuItem{Label: "Machine Details"},
+	}
+
+	addCopyItem := func(label string, value string) {
+		if value == "" {
+			return
+		}
+
+		items = append(items, &ui.LabeledSubmenuItem{
+			Label:           label,
+			AdditionalLabel: value,
+			OnActivate: func() tea.Msg {
+				err := clipboard.WriteString(value)
+				if err != nil {
+					return errorMsg(err)
+				}
+				return successMsg(fmt.Sprintf("Copied %s of %s.", strings.ToLower(label), peerName))
+			},
+		})
+	}
+
+	addInfoItem := func(label string, value string) {
+		if value == "" {
+			return
+		}
+
+		items = append(items, &ui.LabeledSubmenuItem{
+			Label:           label,
+			AdditionalLabel: value,
+			IsDim:           true,
+			OnActivate: func() tea.Msg {
+				err := clipboard.WriteString(value)
+				if err != nil {
+					return errorMsg(err)
+				}
+				return successMsg(fmt.Sprintf("Copied %s of %s.", strings.ToLower(label), peerName))
+			},
+		})
+	}
+
+	fullDomain := trimTrailingDot(peer.DNSName)
+	addCopyItem("Short Domain", peerName)
+	addCopyItem("Full Domain", fullDomain)
+
+	for _, addr := range peer.TailscaleIPs {
+		label := "Tailscale IPv6"
+		if addr.Is4() {
+			label = "Tailscale IPv4"
+		}
+		addCopyItem(label, addr.String())
+	}
+
+	items = append(items, &ui.SpacerSubmenuItem{}, &ui.TitleSubmenuItem{Label: "Details"})
+	addInfoItem("OS Hostname", peer.HostName)
+	addInfoItem("OS", peer.OS)
+	addCopyItem("ID", string(peer.ID))
+	addCopyItem("Node Key", peer.PublicKey.String())
+
+	status := "Offline"
+	if peer.Online {
+		status = "Connected"
+	} else if !peer.LastSeen.IsZero() {
+		status = fmt.Sprintf("Last seen %s ago", ui.FormatDuration(time.Since(peer.LastSeen)))
+	}
+	addInfoItem("Status", status)
+
+	if !peer.Created.IsZero() {
+		addInfoItem("Created", peer.Created.Format(time.RFC822))
+	}
+	if peer.KeyExpiry != nil {
+		addInfoItem("Key Expiry", ui.FormatDuration(time.Until(*peer.KeyExpiry)))
+	}
+	if peer.ExitNodeOption {
+		addInfoItem("Exit Node", "Yes")
+	}
+	if peer.Relay != "" {
+		addInfoItem("Relay", peer.Relay)
+	}
+
+	if len(peer.Addrs) > 0 || peer.CurAddr != "" {
+		items = append(items, &ui.SpacerSubmenuItem{}, &ui.TitleSubmenuItem{Label: "Endpoints"})
+		addInfoItem("Current", peer.CurAddr)
+		for _, addr := range peer.Addrs {
+			addInfoItem("Endpoint", addr)
+		}
+	}
+
+	submenu := &ui.Submenu{}
+	submenu.SetItems(items)
+	return submenu
+}
+
+func trimTrailingDot(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '.' {
+		return s[:len(s)-1]
+	}
+	return s
+}
+
 // Update all of the menu UIs from the current state.
 func (m *model) updateMenus() {
 	if m.state.BackendState == ipn.Running {
@@ -64,9 +168,9 @@ func (m *model) updateMenus() {
 			submenuItems := []ui.SubmenuItem{
 				&ui.TitleSubmenuItem{Label: "Name"},
 				&ui.LabeledSubmenuItem{
-					Label: m.state.Self.DNSName[:len(m.state.Self.DNSName)-1], // Remove the trailing dot.
+					Label: trimTrailingDot(m.state.Self.DNSName),
 					OnActivate: func() tea.Msg {
-						err := clipboard.WriteString(m.state.Self.DNSName[:len(m.state.Self.DNSName)-1])
+						err := clipboard.WriteString(trimTrailingDot(m.state.Self.DNSName))
 						if err != nil {
 							return errorMsg(err)
 						}

--- a/ui/appmenu.go
+++ b/ui/appmenu.go
@@ -140,6 +140,24 @@ func (appmenu *Appmenu) Activate() tea.Cmd {
 	return nil
 }
 
+// Open the child submenu for the selected submenu item, if one exists.
+func (appmenu *Appmenu) OpenChildSubmenu() bool {
+	if !appmenu.isOpen || len(appmenu.items) == 0 {
+		return false
+	}
+
+	return appmenu.items[appmenu.cursor].Submenu.OpenChildSubmenu()
+}
+
+// Close the child submenu for the selected submenu item, if one is open.
+func (appmenu *Appmenu) CloseChildSubmenu() bool {
+	if !appmenu.isOpen || len(appmenu.items) == 0 {
+		return false
+	}
+
+	return appmenu.items[appmenu.cursor].Submenu.CloseChildSubmenu()
+}
+
 // Returns true if a submenu is currently open.
 func (appmenu *Appmenu) IsSubmenuOpen() bool {
 	return appmenu.isOpen

--- a/ui/appmenu.go
+++ b/ui/appmenu.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const appmenuItemWidth = 38
+
 // An item in the main menu, containing a submenu.
 type AppmenuItem struct {
 	// The text to be displayed for this menu item.
@@ -41,7 +43,7 @@ func (i *AppmenuItem) render(isSelected bool, isAnySubmenuOpen bool) string {
 		style.
 			Faint(true).
 			Render(i.AdditionalLabel),
-		35,
+		appmenuItemWidth-3,
 		style,
 	)
 	arrow := style.
@@ -62,8 +64,11 @@ type Appmenu struct {
 }
 
 // Render the menu to a string.
-func (appmenu *Appmenu) Render(height int) string {
+func (appmenu *Appmenu) Render(height int, width int) string {
 	if len(appmenu.items) == 0 {
+		return ""
+	}
+	if width <= 0 {
 		return ""
 	}
 
@@ -76,10 +81,17 @@ func (appmenu *Appmenu) Render(height int) string {
 		s.WriteString(item.render(i == appmenu.cursor, appmenu.isOpen))
 	}
 
+	submenu := &appmenu.items[appmenu.cursor].Submenu
+	if appmenu.isOpen && submenu.HasOpenChildSubmenu() && width < appmenuItemWidth+minSubmenuItemWidth*2 {
+		return submenu.Render(appmenu.isOpen, height, width)
+	}
+
+	submenuWidth := max(0, width-appmenuItemWidth)
+
 	// Render the submenu to the right of the appmenu.
 	return lipgloss.JoinHorizontal(lipgloss.Top,
 		s.String(),
-		appmenu.items[appmenu.cursor].Submenu.Render(appmenu.isOpen, height))
+		submenu.Render(appmenu.isOpen, height, submenuWidth))
 }
 
 // Move the cursor to the next selectable item in the currently active menu.

--- a/ui/submenu.go
+++ b/ui/submenu.go
@@ -19,10 +19,13 @@ type SubmenuItem interface {
 	// If applicable, "un-toggles" the item.
 	clearActiveFlag()
 	// Renders the item. isSelected will always be false if isSelectable() returns false.
-	render(isSelected bool, isSubmenuOpen bool, isFocused bool) string
+	render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string
 }
 
-const submenuItemWidth = 45
+const (
+	defaultSubmenuItemWidth = 45
+	minSubmenuItemWidth     = 24
+)
 
 // Visual variant of a submenu item:
 //
@@ -78,7 +81,7 @@ func (item *LabeledSubmenuItem) childSubmenu() *Submenu {
 	return item.ChildSubmenu
 }
 
-func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	colorStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
@@ -118,7 +121,7 @@ func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFo
 	outerStyle := colorStyle.
 		PaddingRight(1).
 		PaddingLeft(2).
-		Width(submenuItemWidth)
+		Width(width)
 
 	return outerStyle.Render(
 		RenderSplit(
@@ -126,7 +129,7 @@ func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFo
 			colorStyle.
 				Faint(true).
 				Render(item.AdditionalLabel),
-			submenuItemWidth-outerStyle.GetHorizontalPadding(),
+			width-outerStyle.GetHorizontalPadding(),
 			colorStyle,
 		),
 	)
@@ -151,7 +154,7 @@ func (item *ToggleableSubmenuItem) clearActiveFlag() {
 	item.IsActive = false
 }
 
-func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	colorStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
@@ -199,7 +202,7 @@ func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool, i
 
 	outerStyle := colorStyle.
 		Padding(0, 1).
-		Width(submenuItemWidth)
+		Width(width)
 
 	return outerStyle.Render(
 		RenderSplit(
@@ -207,7 +210,7 @@ func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool, i
 			colorStyle.
 				Faint(true).
 				Render(item.AdditionalLabel),
-			submenuItemWidth-outerStyle.GetHorizontalPadding(),
+			width-outerStyle.GetHorizontalPadding(),
 			colorStyle,
 		),
 	)
@@ -272,13 +275,13 @@ func (item *SettingSubmenuItem) onActivate() tea.Cmd {
 
 func (item *SettingSubmenuItem) clearActiveFlag() {}
 
-func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	selectedLabel := item.options[item.selected]
 
 	style := lipgloss.NewStyle().
 		PaddingRight(1).
 		PaddingLeft(2).
-		Width(submenuItemWidth)
+		Width(width)
 	selectedLabelStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
@@ -318,7 +321,7 @@ func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFo
 		RenderSplit(
 			item.Label,
 			selectedLabelStyle.Render(selectedLabel),
-			submenuItemWidth-style.GetHorizontalPadding(),
+			width-style.GetHorizontalPadding(),
 			lipgloss.NewStyle(),
 		),
 	)
@@ -337,7 +340,7 @@ func (d *DividerSubmenuItem) onActivate() tea.Cmd {
 
 func (d *DividerSubmenuItem) clearActiveFlag() {}
 
-func (d *DividerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (d *DividerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	return lipgloss.NewStyle().
 		Faint(true).
 		Render("  --")
@@ -356,7 +359,7 @@ func (s *SpacerSubmenuItem) onActivate() tea.Cmd {
 
 func (s *SpacerSubmenuItem) clearActiveFlag() {}
 
-func (s *SpacerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (s *SpacerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	return ""
 }
 
@@ -376,11 +379,12 @@ func (i *TitleSubmenuItem) onActivate() tea.Cmd {
 
 func (i *TitleSubmenuItem) clearActiveFlag() {}
 
-func (i *TitleSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
+func (i *TitleSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool, width int) string {
 	return lipgloss.NewStyle().
 		Faint(true).
 		PaddingLeft(2).
-		Render(i.Label)
+		Width(width).
+		Render(truncateString(i.Label, width-2))
 }
 
 type SubmenuExclusivity int
@@ -413,12 +417,23 @@ type ComputedSubmenuItem struct {
 }
 
 // Render the submenu to a fixed-height string with scrolling.
-func (submenu *Submenu) Render(isSubmenuOpen bool, height int) string {
+func (submenu *Submenu) Render(isSubmenuOpen bool, height int, width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	itemWidth := min(defaultSubmenuItemWidth, width)
+	childWidth := 0
+	if submenu.selectedChildSubmenu() != nil {
+		childWidth = min(defaultSubmenuItemWidth, max(minSubmenuItemWidth, width/2))
+		itemWidth = max(minSubmenuItemWidth, width-childWidth)
+	}
+
 	// Render all of the computedItems to strings so we can work with their computed heights.
 	computedItems := make([]ComputedSubmenuItem, len(submenu.items))
 	isFocused := isSubmenuOpen && !submenu.childOpen
 	for i, item := range submenu.items {
-		text := item.render(i == submenu.cursor && item.isSelectable(), isSubmenuOpen, isFocused)
+		text := item.render(i == submenu.cursor && item.isSelectable(), isSubmenuOpen, isFocused, itemWidth)
 
 		computedItems[i] = ComputedSubmenuItem{
 			text:   text,
@@ -518,7 +533,7 @@ func (submenu *Submenu) Render(isSubmenuOpen bool, height int) string {
 	if child := submenu.selectedChildSubmenu(); isSubmenuOpen && child != nil {
 		return lipgloss.JoinHorizontal(lipgloss.Top,
 			rendered,
-			child.Render(isSubmenuOpen && submenu.childOpen, height))
+			child.Render(isSubmenuOpen && submenu.childOpen, height, childWidth))
 	}
 
 	return rendered
@@ -620,6 +635,10 @@ func (submenu *Submenu) CloseChildSubmenu() bool {
 
 	submenu.childOpen = false
 	return true
+}
+
+func (submenu *Submenu) HasOpenChildSubmenu() bool {
+	return submenu.childOpen && submenu.selectedChildSubmenu() != nil
 }
 
 // Ensure the cursor is within bounds and on a selectable item. Call after major updates to the items.

--- a/ui/submenu.go
+++ b/ui/submenu.go
@@ -122,17 +122,26 @@ func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFo
 		PaddingRight(1).
 		PaddingLeft(2).
 		Width(width)
+	innerWidth := width - outerStyle.GetHorizontalPadding()
+	rightLabel := colorStyle.
+		Faint(true).
+		Render(item.AdditionalLabel)
 
-	return outerStyle.Render(
-		RenderSplit(
-			colorStyle.Render(item.Label),
+	content := RenderSplit(
+		colorStyle.Render(item.Label),
+		rightLabel,
+		innerWidth,
+		colorStyle,
+	)
+	if item.AdditionalLabel != "" && lipgloss.Width(item.Label)+lipgloss.Width(item.AdditionalLabel)+1 > innerWidth {
+		content = colorStyle.Render(truncateString(item.Label, innerWidth)) + "\n" +
 			colorStyle.
 				Faint(true).
-				Render(item.AdditionalLabel),
-			width-outerStyle.GetHorizontalPadding(),
-			colorStyle,
-		),
-	)
+				Width(innerWidth).
+				Render(item.AdditionalLabel)
+	}
+
+	return outerStyle.Render(content)
 }
 
 // A menu item with a label that can be toggled active or inactive.

--- a/ui/submenu.go
+++ b/ui/submenu.go
@@ -19,7 +19,7 @@ type SubmenuItem interface {
 	// If applicable, "un-toggles" the item.
 	clearActiveFlag()
 	// Renders the item. isSelected will always be false if isSelectable() returns false.
-	render(isSelected bool, isSubmenuOpen bool) string
+	render(isSelected bool, isSubmenuOpen bool, isFocused bool) string
 }
 
 const submenuItemWidth = 45
@@ -52,6 +52,8 @@ type LabeledSubmenuItem struct {
 	Label string
 	// An extra label shown on the right side. Will be shown in a muted color.
 	AdditionalLabel string
+	// Optional submenu shown to the right when this item is selected.
+	ChildSubmenu *Submenu
 	// Visual variant.
 	Variant SubmenuItemVariant
 	// Callback when the item is activated.
@@ -72,11 +74,15 @@ func (item *LabeledSubmenuItem) clearActiveFlag() {
 	// No-op because this item is not toggleable.
 }
 
-func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (item *LabeledSubmenuItem) childSubmenu() *Submenu {
+	return item.ChildSubmenu
+}
+
+func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	colorStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
-		if isSelected {
+		if isSelected && isFocused {
 			if item.Variant == SubmenuItemVariantDanger {
 				colorStyle = colorStyle.
 					Background(Red).
@@ -86,6 +92,10 @@ func (item *LabeledSubmenuItem) render(isSelected bool, isSubmenuOpen bool) stri
 					Background(Secondary).
 					Foreground(Black)
 			}
+		} else if isSelected {
+			colorStyle = colorStyle.
+				Background(DarkGray).
+				Faint(true)
 		} else if item.IsDim {
 			colorStyle = colorStyle.
 				Faint(true)
@@ -141,7 +151,7 @@ func (item *ToggleableSubmenuItem) clearActiveFlag() {
 	item.IsActive = false
 }
 
-func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	colorStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
@@ -155,10 +165,14 @@ func (item *ToggleableSubmenuItem) render(isSelected bool, isSubmenuOpen bool) s
 			}
 		}
 
-		if isSelected {
+		if isSelected && isFocused {
 			colorStyle = colorStyle.
 				Background(Secondary).
 				Foreground(Black)
+		} else if isSelected {
+			colorStyle = colorStyle.
+				Background(DarkGray).
+				Faint(true)
 		} else if item.IsDim {
 			colorStyle = colorStyle.
 				Faint(true)
@@ -258,7 +272,7 @@ func (item *SettingSubmenuItem) onActivate() tea.Cmd {
 
 func (item *SettingSubmenuItem) clearActiveFlag() {}
 
-func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	selectedLabel := item.options[item.selected]
 
 	style := lipgloss.NewStyle().
@@ -268,13 +282,17 @@ func (item *SettingSubmenuItem) render(isSelected bool, isSubmenuOpen bool) stri
 	selectedLabelStyle := lipgloss.NewStyle()
 
 	if isSubmenuOpen {
-		if isSelected {
+		if isSelected && isFocused {
 			style = style.
 				Background(Secondary).
 				Foreground(Black)
 
 			selectedLabelStyle = selectedLabelStyle.
 				Bold(true)
+		} else if isSelected {
+			style = style.
+				Background(DarkGray).
+				Faint(true)
 		} else {
 			var color lipgloss.Color
 
@@ -319,7 +337,7 @@ func (d *DividerSubmenuItem) onActivate() tea.Cmd {
 
 func (d *DividerSubmenuItem) clearActiveFlag() {}
 
-func (d *DividerSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (d *DividerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	return lipgloss.NewStyle().
 		Faint(true).
 		Render("  --")
@@ -338,7 +356,7 @@ func (s *SpacerSubmenuItem) onActivate() tea.Cmd {
 
 func (s *SpacerSubmenuItem) clearActiveFlag() {}
 
-func (s *SpacerSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (s *SpacerSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	return ""
 }
 
@@ -358,7 +376,7 @@ func (i *TitleSubmenuItem) onActivate() tea.Cmd {
 
 func (i *TitleSubmenuItem) clearActiveFlag() {}
 
-func (i *TitleSubmenuItem) render(isSelected bool, isSubmenuOpen bool) string {
+func (i *TitleSubmenuItem) render(isSelected bool, isSubmenuOpen bool, isFocused bool) string {
 	return lipgloss.NewStyle().
 		Faint(true).
 		PaddingLeft(2).
@@ -381,6 +399,11 @@ type Submenu struct {
 	Exclusivity SubmenuExclusivity
 	items       []SubmenuItem
 	cursor      int
+	childOpen   bool
+}
+
+type childSubmenuItem interface {
+	childSubmenu() *Submenu
 }
 
 // A rendered submenu item and its computed layout info.
@@ -393,8 +416,9 @@ type ComputedSubmenuItem struct {
 func (submenu *Submenu) Render(isSubmenuOpen bool, height int) string {
 	// Render all of the computedItems to strings so we can work with their computed heights.
 	computedItems := make([]ComputedSubmenuItem, len(submenu.items))
+	isFocused := isSubmenuOpen && !submenu.childOpen
 	for i, item := range submenu.items {
-		text := item.render(i == submenu.cursor && item.isSelectable(), isSubmenuOpen)
+		text := item.render(i == submenu.cursor && item.isSelectable(), isSubmenuOpen, isFocused)
 
 		computedItems[i] = ComputedSubmenuItem{
 			text:   text,
@@ -490,14 +514,42 @@ func (submenu *Submenu) Render(isSubmenuOpen bool, height int) string {
 		s.WriteString("\n" + overflow)
 	}
 
-	return s.String()
+	rendered := s.String()
+	if child := submenu.selectedChildSubmenu(); isSubmenuOpen && child != nil {
+		return lipgloss.JoinHorizontal(lipgloss.Top,
+			rendered,
+			child.Render(isSubmenuOpen && submenu.childOpen, height))
+	}
+
+	return rendered
+}
+
+func (submenu *Submenu) selectedChildSubmenu() *Submenu {
+	if submenu.cursor < 0 || submenu.cursor >= len(submenu.items) {
+		return nil
+	}
+
+	item, ok := submenu.items[submenu.cursor].(childSubmenuItem)
+	if !ok {
+		return nil
+	}
+
+	return item.childSubmenu()
 }
 
 // Move the cursor to the next selectable item.
 func (submenu *Submenu) CursorDown() {
+	if submenu.childOpen {
+		if child := submenu.selectedChildSubmenu(); child != nil {
+			child.CursorDown()
+			return
+		}
+	}
+
 	for i := submenu.cursor + 1; i < len(submenu.items); i++ {
 		if submenu.items[i].isSelectable() {
 			submenu.cursor = i
+			submenu.childOpen = false
 			return
 		}
 	}
@@ -505,9 +557,17 @@ func (submenu *Submenu) CursorDown() {
 
 // Move the cursor to the previous selectable item.
 func (submenu *Submenu) CursorUp() {
+	if submenu.childOpen {
+		if child := submenu.selectedChildSubmenu(); child != nil {
+			child.CursorUp()
+			return
+		}
+	}
+
 	for i := submenu.cursor - 1; i >= 0; i-- {
 		if submenu.items[i].isSelectable() {
 			submenu.cursor = i
+			submenu.childOpen = false
 			return
 		}
 	}
@@ -515,6 +575,7 @@ func (submenu *Submenu) CursorUp() {
 
 // Reset the cursor to the first selectable item.
 func (submenu *Submenu) ResetCursor() {
+	submenu.childOpen = false
 	for i, item := range submenu.items {
 		if item.isSelectable() {
 			submenu.cursor = i
@@ -525,8 +586,40 @@ func (submenu *Submenu) ResetCursor() {
 
 // Set the items list and ensure the cursor is within bounds and on a selectable item.
 func (submenu *Submenu) SetItems(items []SubmenuItem) {
+	childOpen := submenu.childOpen
+	childCursor := 0
+	if child := submenu.selectedChildSubmenu(); child != nil {
+		childCursor = child.cursor
+	}
+
 	submenu.items = items
 	submenu.fixCursor()
+	submenu.childOpen = childOpen && submenu.selectedChildSubmenu() != nil
+	if submenu.childOpen {
+		child := submenu.selectedChildSubmenu()
+		child.cursor = childCursor
+		child.fixCursor()
+	}
+}
+
+func (submenu *Submenu) OpenChildSubmenu() bool {
+	child := submenu.selectedChildSubmenu()
+	if child == nil {
+		return false
+	}
+
+	submenu.childOpen = true
+	child.ResetCursor()
+	return true
+}
+
+func (submenu *Submenu) CloseChildSubmenu() bool {
+	if !submenu.childOpen {
+		return false
+	}
+
+	submenu.childOpen = false
+	return true
 }
 
 // Ensure the cursor is within bounds and on a selectable item. Call after major updates to the items.
@@ -547,6 +640,12 @@ func (submenu *Submenu) fixCursor() {
 // Call the currently selected item's activate callback.
 // Returns a bubbletea command that can be run asynchronously.
 func (submenu *Submenu) Activate() tea.Cmd {
+	if submenu.childOpen {
+		if child := submenu.selectedChildSubmenu(); child != nil {
+			return child.Activate()
+		}
+	}
+
 	if submenu.cursor < 0 || submenu.cursor >= len(submenu.items) {
 		return nil
 	}

--- a/ui/util.go
+++ b/ui/util.go
@@ -49,9 +49,24 @@ func FormatBytes(bytes int64) string {
 // Takes a style which is used for formatting the left-side padding, in case
 // a uniform background is required.
 func RenderSplit(left string, right string, width int, style lipgloss.Style) string {
+	if width <= 0 {
+		return ""
+	}
+
+	if lipgloss.Width(right) >= width {
+		return style.Width(width).Render(truncateString(right, width))
+	}
+
 	left = style.
 		Width(width - lipgloss.Width(right)).
-		Render(left)
+		Render(truncateString(left, width-lipgloss.Width(right)))
 
 	return left + right
+}
+
+func truncateString(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return lipgloss.NewStyle().MaxWidth(width).Render(s)
 }

--- a/update.go
+++ b/update.go
@@ -121,14 +121,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "esc":
-			if m.menu.IsSubmenuOpen() {
+			if m.menu.CloseChildSubmenu() {
+				return m, nil
+			} else if m.menu.IsSubmenuOpen() {
 				m.menu.CloseSubmenu()
 			} else {
 				return m, tea.Quit
 			}
 
 		case "left", "h", "a":
-			m.menu.CloseSubmenu()
+			if !m.menu.CloseChildSubmenu() {
+				m.menu.CloseSubmenu()
+			}
 		case "up", "k", "w":
 			m.menu.CursorUp()
 		case "down", "j", "s":
@@ -137,6 +141,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !m.menu.IsSubmenuOpen() {
 				return m, m.menu.Activate()
 			}
+			m.menu.OpenChildSubmenu()
 
 		case "enter", " ":
 			return m, m.menu.Activate()

--- a/view.go
+++ b/view.go
@@ -245,7 +245,7 @@ func (m model) View() string {
 	case ipn.Running:
 		middle = lipgloss.NewStyle().
 			Height(middleHeight).
-			Render(m.menu.Render(middleHeight))
+			Render(m.menu.Render(middleHeight, m.terminalWidth))
 
 	case ipn.NeedsMachineAuth:
 		// TODO: Figure out what this state actually is so we can be helpful to the user.


### PR DESCRIPTION
## Summary
- Add a contextual machine details column for network devices.
- Keep the existing default action on a device row: pressing Enter still copies the first Tailscale IP.
- Allow pressing Right to focus the details column and choose a specific value to copy.
- Include copyable peer details such as short/full domain, Tailscale IPs, node ID, node key, status, relay, and endpoints.
- Preserve both the open details column and its highlighted row across periodic state refreshes.
- Show an inactive highlight on the parent device row while the details column is focused, so it stays clear which machine the details belong to.
- Make nested menu rendering responsive for narrow terminals: when there is not enough room for all three columns, hide the leftmost app menu while the details column is open and split the available width between device list and details.

## Notes
- This adds generic child-submenu support to the existing menu UI so nested details can be reused without special-casing network devices.
- The machine details are limited to fields available from Tailscale's local PeerStatus.
- The layout should adapt to the terminal width instead of requiring a fixed 80-column or wider launcher window.

## Tests
- go test ./...